### PR TITLE
updated recipe for 0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.1.5" %}
+{% set version = "0.2.0" %}
 {% set hash_type = "md5" %}
-{% set hash_val = "3790f06bf6006840bf3d64ef5fc2803f" %}
+{% set hash_val = "b31e2724dc908ff6beec120a8bfdb42c" %}
 
 package:
   name: resampy
@@ -12,25 +12,25 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
-    - numpy x.x
+    - numpy >=1.8.0
     - scipy >=0.13
     - six >=1.3
-    - cython >=0.23
+    - numba >=0.32
 
   run:
     - python
     - setuptools # necessary for pkg_resources at runtime
-    - numpy x.x
+    - numpy >=1.8.0
     - scipy >=0.13
     - six >=1.3
-    - cython >=0.23 # necessary for runtime cython dependency
+    - numba >=0.32
 
 test:
   imports:


### PR DESCRIPTION
This PR updates the recipe for the 0.2.0 release.

The cython dependency has been dropped and a numba dependency has been added.