### PR TITLE
Second build of 0.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
Somehow, the OSX build for 0.2.0 wound up with two archives having different checksums.  Trying a new push to fix that.  This PR includes no substantive changes.